### PR TITLE
update Flask to 2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.2
+Flask==2.1.1
 requests==2.25.1


### PR DESCRIPTION
The app is currently giving a 502 error when one attempts to view it after deployment. Looking at the logs, we're seeing `ImportError: cannot import name 'escape' from 'jinja2'` and `importerror: cannot import name 'json' from 'itsdangerous'`.

These appear to be issues with Flask 1.x dependencies since the app isn't directly pulling either of those packages. [itsdangerous solution](https://exerror.com/importerror-cannot-import-name-json-from-itsdangerous/#:~:text='%20from%20'itsdangerous'-,To%20Solve%20ImportError%3A%20cannot%20import%20name%20'json'%20from%20',it%20will%20solve%20your%20error.) [jinja2 solution](https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2)

I tested the Qwiklab with this change and it resolved the issue.